### PR TITLE
Fix for PIR handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ This should be turned into a JSON object that looks like this:
 
 This code is MIT licenced, and we don't claim it to be excellent, pull requests are encouraged! This isn't yet complete, it doesn't yet support accelerometer payloads for example. Again, pull request!
 
+## Note to LoraServer users
+
+If you using the codec with LoraServer then change the name of the method and the orders of paprameters to Decode(port, bytes)
+
 ## Contributors
 Many thanks to:
  * [avbentem](https://github.com/avbentem) for suggesting fixes to negative temperature and PIR handling
+ * [m-markovic] (https://github.com/m-markovic) PIR handling
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ This should be turned into a JSON object that looks like this:
 
 This code is MIT licenced, and we don't claim it to be excellent, pull requests are encouraged! This isn't yet complete, it doesn't yet support accelerometer payloads for example. Again, pull request!
 
-## Note to LoraServer users
+## Note to ChirpStack (formerly LoraServer) users
 
-If you are using this codec with LoraServer then change the name of the method and the orders of paprameters to Decode(port, bytes)
+If you are using this codec with ChirpStack then change the name of the method and the orders of parameters to Decode(port, bytes)
 
 ## Contributors
 Many thanks to:

--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ If you are using this codec with LoraServer then change the name of the method a
 ## Contributors
 Many thanks to:
  * [avbentem](https://github.com/avbentem) for suggesting fixes to negative temperature and PIR handling
- * [m-markovic] (https://github.com/m-markovic) PIR handling
+ * [m-markovic](https://github.com/m-markovic) PIR handling
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This code is MIT licenced, and we don't claim it to be excellent, pull requests 
 
 ## Note to LoraServer users
 
-If you using the codec with LoraServer then change the name of the method and the orders of paprameters to Decode(port, bytes)
+If you are using this codec with LoraServer then change the name of the method and the orders of paprameters to Decode(port, bytes)
 
 ## Contributors
 Many thanks to:

--- a/tektelic-kona-home-ttn-decoder.js
+++ b/tektelic-kona-home-ttn-decoder.js
@@ -41,13 +41,18 @@ function Decoder(bytes, port) {
         }
         
         // Handle PIR activity
+        //check the channel and type
         if(0x0A === bytes[i] && 0x00 === bytes[i+1]) {
+          i = i+1;
+          //check data
+          if (0x00 === bytes[i+1]) {
+             params.activity = false;
+             i = i+1;
+          }
+          else if( 0xFF === bytes[i+1]) {
             params.activity = true;
             i = i+1;
-        }
-        else if(0x0A === bytes[i] && 0xFF === bytes[i+1]) {
-            params.activity = false;
-            i = i+1;
+          }
         }
         
         // Handle reed switch state


### PR DESCRIPTION
Previous version showed activity always as true even if  inactivity was reported. This was because the if statement didn't check the data but only the data type which is always 0x00.